### PR TITLE
feat: Add mini calendar for improved navigation

### DIFF
--- a/src/components/MiniCalendar.vue
+++ b/src/components/MiniCalendar.vue
@@ -37,7 +37,7 @@ const daysGrid = computed<DayObject[]>(() => {
   const month = displayMonth.value.getMonth();
 
   const firstDayOfMonth = new Date(year, month, 1);
-  
+
   // Start date is the Sunday of the week the first day of the month falls in
   const startDate = new Date(firstDayOfMonth);
   startDate.setDate(startDate.getDate() - firstDayOfMonth.getDay()); // .getDay() is 0 for Sun, 1 for Mon...
@@ -78,26 +78,19 @@ function selectDay(day: DayObject) {
     displayMonth.value = new Date(day.date.getFullYear(), day.date.getMonth(), 1);
     // No need to emit 'navigate-month' here if the main calendar handles month changes based on 'date-selected'
     // However, if mini-calendar should independently signal month navigation on such clicks:
-    // emit('navigate-month', new Date(displayMonth.value)); 
+    // emit('navigate-month', new Date(displayMonth.value));
   }
 }
 
 watch(() => props.currentDate, (newVal) => {
   // Update displayMonth if the main calendar's month changes,
   // but avoid feedback loop if mini-calendar initiated the change.
-  if (newVal.getFullYear() !== displayMonth.value.getFullYear() || 
+  if (newVal.getFullYear() !== displayMonth.value.getFullYear() ||
       newVal.getMonth() !== displayMonth.value.getMonth()) {
     displayMonth.value = new Date(newVal);
   }
 }, { immediate: true }); // Use immediate to set initial displayMonth correctly based on prop
 
-// Watch selectedDate to ensure reactivity if it changes from parent
-// The daysGrid computed property will automatically update based on props.selectedDate
-// No explicit action needed in the watcher itself for re-rendering, computed handles it.
-watch(() => props.selectedDate, () => {
-  // This watcher ensures that if props.selectedDate changes,
-  // the component reacts, and computed properties depending on it are re-evaluated.
-});
 
 </script>
 

--- a/src/components/MiniCalendar.vue
+++ b/src/components/MiniCalendar.vue
@@ -18,7 +18,10 @@ const emit = defineEmits(['date-selected', 'navigate-month']);
 
 const displayMonth = ref(new Date(props.currentDate)); // Initialize with current month from main calendar
 
-const weekdays = ['S', 'M', 'T', 'W', 'T', 'F', 'S']; // Or use Intl for localization
+const weekdays = Array.from({ length: 7 }, (_, i) => {
+  const date = new Date(2021, 0, i + 3); // Jan 3, 2021 was a Sunday
+  return new Intl.DateTimeFormat(undefined, { weekday: 'narrow' }).format(date);
+});
 
 const formattedMonthYear = computed(() => {
   return displayMonth.value.toLocaleDateString(undefined, { month: 'long', year: 'numeric' });
@@ -107,7 +110,7 @@ watch(() => props.currentDate, (newVal) => {
     <div class="mini-calendar-grid">
       <div
         v-for="(day, index) in daysGrid"
-        :key="index"
+        :key="`${day.date.getFullYear()}-${day.date.getMonth()}-${day.date.getDate()}`"
         class="day-cell"
         :class="{
           'other-month': !day.isCurrentMonth,
@@ -123,7 +126,6 @@ watch(() => props.currentDate, (newVal) => {
       >
         {{ day.dayNumber }}
       </div>
-    </div>
   </div>
 </template>
 
@@ -234,9 +236,12 @@ watch(() => props.currentDate, (newVal) => {
 
 .day-cell.today {
   font-weight: bold;
-  /* border: 1px solid #1a73e8;  Blue border for today */
-  /* color: #1a73e8; Blue text for today */
+.day-cell.today {
+  font-weight: bold;
   background-color: #ebf4ff; /* Light blue background for today */
+  border: 1px solid #cce0ff; /* Slightly darker blue border for today */
+  color: #005fc9; /* Darker blue text for today */
+}
   border: 1px solid #cce0ff; /* Slightly darker blue border for today */
   color: #005fc9; /* Darker blue text for today */
 }

--- a/src/components/MiniCalendar.vue
+++ b/src/components/MiniCalendar.vue
@@ -129,7 +129,7 @@ watch(() => props.currentDate, (newVal) => {
 
 <style scoped>
 .mini-calendar {
-  width: 230px; /* Adjusted width */
+  width: 220px; /* Adjusted width */
   padding: 8px;
   background-color: #fff;
   border: 1px solid #e0e0e0; /* Softer border */
@@ -153,14 +153,23 @@ watch(() => props.currentDate, (newVal) => {
 }
 
 .nav-button {
+  width: 36px;
+  aspect-ratio: 1 / 1;
+  height: auto;
+  min-width: 0;
+  min-height: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
   background: transparent;
-  border: none; /* Removed border */
+  border: none;
   cursor: pointer;
-  padding: 4px 8px; /* Adjusted padding */
-  border-radius: 4px; /* More rounded */
-  font-size: 1.1em; /* Larger arrows */
+  border-radius: 8px;
+  font-size: 1.1em;
   color: #555;
   transition: background-color 0.2s;
+  padding: 0;
+  box-sizing: border-box;
 }
 .nav-button:hover {
   background-color: #f0f0f0; /* Hover effect */
@@ -187,19 +196,23 @@ watch(() => props.currentDate, (newVal) => {
 }
 
 .day-cell {
-  padding: 6px 0; /* Adjusted padding, no horizontal padding needed due to text-align */
+  width: 30px;
+  aspect-ratio: 1 / 1;
+  height: auto;
+  min-width: 0;
+  min-height: 0;
+  padding: 0;
   text-align: center;
-  border: 1px solid transparent; /* Transparent border for spacing */
-  font-size: 0.85em; /* Slightly smaller day numbers */
+  border: 1px solid transparent;
+  font-size: 0.85em;
   cursor: pointer;
-  border-radius: 4px; /* Rounded cells */
+  border-radius: 4px;
   transition: background-color 0.2s, border-color 0.2s;
   color: #444;
-  line-height: 1.2; /* Ensure consistent height */
-  min-height: 28px; /* Fixed height */
   display: flex;
   align-items: center;
   justify-content: center;
+  box-sizing: border-box;
 }
 
 .day-cell:hover {

--- a/src/components/MiniCalendar.vue
+++ b/src/components/MiniCalendar.vue
@@ -1,0 +1,262 @@
+<script setup lang="ts">
+import { ref, computed, watch, defineProps, defineEmits } from 'vue';
+
+interface DayObject {
+  date: Date;
+  dayNumber: number;
+  isCurrentMonth: boolean;
+  isToday: boolean;
+  isSelected: boolean;
+}
+
+const props = defineProps<{
+  currentDate: Date;
+  selectedDate: Date | null;
+}>();
+
+const emit = defineEmits(['date-selected', 'navigate-month']);
+
+const displayMonth = ref(new Date(props.currentDate)); // Initialize with current month from main calendar
+
+const weekdays = ['S', 'M', 'T', 'W', 'T', 'F', 'S']; // Or use Intl for localization
+
+const formattedMonthYear = computed(() => {
+  return displayMonth.value.toLocaleDateString(undefined, { month: 'long', year: 'numeric' });
+});
+
+function isSameDay(date1: Date, date2: Date | null): boolean {
+  if (!date2) return false;
+  return date1.getFullYear() === date2.getFullYear() &&
+         date1.getMonth() === date2.getMonth() &&
+         date1.getDate() === date2.getDate();
+}
+
+const daysGrid = computed<DayObject[]>(() => {
+  const days: DayObject[] = [];
+  const year = displayMonth.value.getFullYear();
+  const month = displayMonth.value.getMonth();
+
+  const firstDayOfMonth = new Date(year, month, 1);
+  
+  // Start date is the Sunday of the week the first day of the month falls in
+  const startDate = new Date(firstDayOfMonth);
+  startDate.setDate(startDate.getDate() - firstDayOfMonth.getDay()); // .getDay() is 0 for Sun, 1 for Mon...
+
+  // Generate 42 days (6 weeks)
+  for (let i = 0; i < 42; i++) {
+    const currentDatePointer = new Date(startDate);
+    currentDatePointer.setDate(startDate.getDate() + i);
+
+    days.push({
+      date: new Date(currentDatePointer),
+      dayNumber: currentDatePointer.getDate(),
+      isCurrentMonth: currentDatePointer.getMonth() === month,
+      isToday: isSameDay(currentDatePointer, new Date()),
+      isSelected: isSameDay(currentDatePointer, props.selectedDate),
+    });
+  }
+  return days;
+});
+
+function prevMonth() {
+  displayMonth.value = new Date(displayMonth.value.getFullYear(), displayMonth.value.getMonth() - 1, 1);
+  emit('navigate-month', new Date(displayMonth.value));
+}
+
+function nextMonth() {
+  displayMonth.value = new Date(displayMonth.value.getFullYear(), displayMonth.value.getMonth() + 1, 1);
+  emit('navigate-month', new Date(displayMonth.value));
+}
+
+function selectDay(day: DayObject) {
+  // Emit date-selected for the main calendar to pick up
+  // The main calendar can decide if it wants to navigate months if day is not in current month
+  emit('date-selected', day.date);
+
+  // If a day from another month is clicked, also navigate the mini-calendar to that month
+  if (!day.isCurrentMonth) {
+    displayMonth.value = new Date(day.date.getFullYear(), day.date.getMonth(), 1);
+    // No need to emit 'navigate-month' here if the main calendar handles month changes based on 'date-selected'
+    // However, if mini-calendar should independently signal month navigation on such clicks:
+    // emit('navigate-month', new Date(displayMonth.value)); 
+  }
+}
+
+watch(() => props.currentDate, (newVal) => {
+  // Update displayMonth if the main calendar's month changes,
+  // but avoid feedback loop if mini-calendar initiated the change.
+  if (newVal.getFullYear() !== displayMonth.value.getFullYear() || 
+      newVal.getMonth() !== displayMonth.value.getMonth()) {
+    displayMonth.value = new Date(newVal);
+  }
+}, { immediate: true }); // Use immediate to set initial displayMonth correctly based on prop
+
+// Watch selectedDate to ensure reactivity if it changes from parent
+// The daysGrid computed property will automatically update based on props.selectedDate
+// No explicit action needed in the watcher itself for re-rendering, computed handles it.
+watch(() => props.selectedDate, () => {
+  // This watcher ensures that if props.selectedDate changes,
+  // the component reacts, and computed properties depending on it are re-evaluated.
+});
+
+</script>
+
+<template>
+  <div class="mini-calendar">
+    <div class="mini-calendar-header">
+      <button @click="prevMonth" class="nav-button prev-month" aria-label="Previous month">&lt;</button>
+      <span class="month-year">{{ formattedMonthYear }}</span>
+      <button @click="nextMonth" class="nav-button next-month" aria-label="Next month">&gt;</button>
+    </div>
+    <div class="mini-calendar-weekdays">
+      <span v-for="weekday in weekdays" :key="weekday">{{ weekday }}</span>
+    </div>
+    <div class="mini-calendar-grid">
+      <div
+        v-for="(day, index) in daysGrid"
+        :key="index"
+        class="day-cell"
+        :class="{
+          'other-month': !day.isCurrentMonth,
+          'today': day.isToday,
+          'selected': day.isSelected,
+        }"
+        @click="selectDay(day)"
+        role="button"
+        :aria-label="`Select date ${day.date.toDateString()}`"
+        :aria-selected="day.isSelected"
+        tabindex="0"
+        @keydown.enter="selectDay(day)" @keydown.space="selectDay(day)"
+      >
+        {{ day.dayNumber }}
+      </div>
+    </div>
+  </div>
+</template>
+
+<style scoped>
+.mini-calendar {
+  width: 230px; /* Adjusted width */
+  padding: 8px;
+  background-color: #fff;
+  border: 1px solid #e0e0e0; /* Softer border */
+  border-radius: 6px; /* Slightly more rounded */
+  box-shadow: 0 1px 3px rgba(0,0,0,0.05);
+  font-family: system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, 'Open Sans', 'Helvetica Neue', sans-serif;
+}
+
+.mini-calendar-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: 8px; /* Reduced margin */
+  padding: 4px 0;
+}
+
+.month-year {
+  font-weight: 600; /* Slightly bolder */
+  font-size: 0.95em; /* Adjusted size */
+  color: #333;
+}
+
+.nav-button {
+  background: transparent;
+  border: none; /* Removed border */
+  cursor: pointer;
+  padding: 4px 8px; /* Adjusted padding */
+  border-radius: 4px; /* More rounded */
+  font-size: 1.1em; /* Larger arrows */
+  color: #555;
+  transition: background-color 0.2s;
+}
+.nav-button:hover {
+  background-color: #f0f0f0; /* Hover effect */
+  color: #111;
+}
+
+.mini-calendar-weekdays {
+  display: grid;
+  grid-template-columns: repeat(7, 1fr);
+  text-align: center;
+  margin-bottom: 6px; /* Adjusted margin */
+  font-size: 0.75em; /* Smaller weekday text */
+  font-weight: 500;
+  color: #777; /* Greyer weekday text */
+}
+.mini-calendar-weekdays span {
+  padding: 2px 0;
+}
+
+.mini-calendar-grid {
+  display: grid;
+  grid-template-columns: repeat(7, 1fr);
+  gap: 1px; /* Reduced gap for tighter grid */
+}
+
+.day-cell {
+  padding: 6px 0; /* Adjusted padding, no horizontal padding needed due to text-align */
+  text-align: center;
+  border: 1px solid transparent; /* Transparent border for spacing */
+  font-size: 0.85em; /* Slightly smaller day numbers */
+  cursor: pointer;
+  border-radius: 4px; /* Rounded cells */
+  transition: background-color 0.2s, border-color 0.2s;
+  color: #444;
+  line-height: 1.2; /* Ensure consistent height */
+  min-height: 28px; /* Fixed height */
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.day-cell:hover {
+  background-color: #e9eff8; /* Light blue hover */
+  border-color: #d0d8e0;
+}
+.day-cell:focus, .day-cell:focus-visible {
+  outline: 2px solid #1a73e8;
+  outline-offset: 1px;
+}
+
+
+.day-cell.other-month {
+  color: #aaa; /* Lighter text for other month days */
+}
+.day-cell.other-month:hover {
+  background-color: #f4f4f4;
+}
+
+.day-cell.today {
+  font-weight: bold;
+  /* border: 1px solid #1a73e8;  Blue border for today */
+  /* color: #1a73e8; Blue text for today */
+  background-color: #ebf4ff; /* Light blue background for today */
+  border: 1px solid #cce0ff; /* Slightly darker blue border for today */
+  color: #005fc9; /* Darker blue text for today */
+}
+.day-cell.today:hover {
+  background-color: #ddeafd;
+}
+
+.day-cell.selected {
+  background-color: #1a73e8; /* Blue background for selected */
+  color: white;
+  border-color: #1a73e8;
+  font-weight: bold;
+}
+.day-cell.selected:hover {
+  background-color: #145cb7; /* Darker blue on hover for selected */
+  border-color: #145cb7;
+}
+
+/* Ensure selected today has distinct styling if needed, but selected usually overrides today visual */
+.day-cell.selected.today {
+  background-color: #1a73e8; /* Standard selected style */
+  color: white;
+  border-color: #1a73e8;
+}
+.day-cell.selected.today:hover {
+   background-color: #145cb7;
+   border-color: #145cb7;
+}
+</style>

--- a/src/components/MiniCalendar.vue
+++ b/src/components/MiniCalendar.vue
@@ -109,7 +109,7 @@ watch(() => props.currentDate, (newVal) => {
     </div>
     <div class="mini-calendar-grid">
       <div
-        v-for="(day, index) in daysGrid"
+        v-for="(day) in daysGrid"
         :key="`${day.date.getFullYear()}-${day.date.getMonth()}-${day.date.getDate()}`"
         class="day-cell"
         :class="{
@@ -126,6 +126,7 @@ watch(() => props.currentDate, (newVal) => {
       >
         {{ day.dayNumber }}
       </div>
+    </div>
   </div>
 </template>
 

--- a/src/components/MiniCalendar.vue
+++ b/src/components/MiniCalendar.vue
@@ -132,7 +132,8 @@ watch(() => props.currentDate, (newVal) => {
         :aria-label="`Select date ${day.date.toDateString()}`"
         :aria-selected="day.isSelected"
         tabindex="0"
-        @keydown.enter="selectDay(day)" @keydown.space="selectDay(day)"
+        @keydown.enter="selectDay(day)"
+        @keydown.space.prevent="selectDay(day)"
       >
         {{ day.dayNumber }}
       </div>

--- a/src/components/MiniCalendar.vue
+++ b/src/components/MiniCalendar.vue
@@ -237,12 +237,7 @@ watch(() => props.currentDate, (newVal) => {
 
 .day-cell.today {
   font-weight: bold;
-.day-cell.today {
-  font-weight: bold;
   background-color: #ebf4ff; /* Light blue background for today */
-  border: 1px solid #cce0ff; /* Slightly darker blue border for today */
-  color: #005fc9; /* Darker blue text for today */
-}
   border: 1px solid #cce0ff; /* Slightly darker blue border for today */
   color: #005fc9; /* Darker blue text for today */
 }

--- a/src/components/MiniCalendar.vue
+++ b/src/components/MiniCalendar.vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
 import { ref, computed, watch, defineProps, defineEmits } from 'vue';
+import type { PropType } from 'vue';
 
 interface DayObject {
   date: Date;
@@ -9,10 +10,19 @@ interface DayObject {
   isSelected: boolean;
 }
 
-const props = defineProps<{
-  currentDate: Date;
-  selectedDate: Date | null;
-}>();
+const props = defineProps({
+  currentDate: {
+    type: Object as PropType<Date>,
+    required: true,
+    validator: (val: unknown) => val instanceof Date && !isNaN(val.getTime()),
+  },
+  selectedDate: {
+    type: Object as PropType<Date | null>,
+    required: false,
+    default: null,
+    validator: (val: unknown) => val === null || (val instanceof Date && !isNaN(val.getTime())),
+  },
+});
 
 const emit = defineEmits(['date-selected', 'navigate-month']);
 

--- a/src/components/MyCalendar.vue
+++ b/src/components/MyCalendar.vue
@@ -1,13 +1,12 @@
 <template>
   <div class="calendar-app-layout">
     <aside class="calendar-sidebar">
-      <!-- Mini calendar placeholder -->
-      <div class="mini-calendar-placeholder">
-        <div class="mini-calendar-header">
-          <span>June 2025</span>
-        </div>
-        <div class="mini-calendar-grid">(Mini calendar here)</div>
-      </div>
+      <MiniCalendar
+        :current-date="currentDate"
+        :selected-date="selectedDate"
+        @date-selected="handleMiniCalendarDateSelected"
+        @navigate-month="handleMiniCalendarNavigateMonth"
+      />
       <!-- Search bar -->
       <input
         type="text"
@@ -254,6 +253,7 @@
 
 <script setup lang="ts">
 import { ref, computed, watch, onMounted, inject, provide, nextTick, onBeforeUnmount } from 'vue';
+import MiniCalendar from './MiniCalendar.vue';
 import EventCard from './EventCard.vue';
 import {
   type CalendarEvent,
@@ -994,6 +994,16 @@ onBeforeUnmount(() => {
 
 function closeViewDropdown() {
   viewDropdownOpen.value = false;
+}
+
+// --- Mini Calendar Event Handlers ---
+function handleMiniCalendarDateSelected(date: Date): void {
+  currentDate.value = new Date(date);
+  selectedDate.value = new Date(date);
+}
+
+function handleMiniCalendarNavigateMonth(date: Date): void {
+  currentDate.value = new Date(date.getFullYear(), date.getMonth(), 1);
 }
 </script>
 
@@ -1764,32 +1774,6 @@ function closeViewDropdown() {
   outline: none;
 }
 
-/* Add after .calendar-sidebar styles */
-.mini-calendar-placeholder {
-  background: #fff;
-  border-radius: 12px;
-  box-shadow: 0 1px 4px rgba(60, 72, 88, 0.06);
-  padding: 16px 12px 12px 12px;
-  margin-bottom: 24px;
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-}
-.mini-calendar-header {
-  font-size: 15px;
-  font-weight: 600;
-  color: #222;
-  margin-bottom: 8px;
-}
-.mini-calendar-grid {
-  font-size: 13px;
-  color: #888;
-  text-align: center;
-  min-height: 80px;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-}
 .sidebar-search {
   width: 100%;
   box-sizing: border-box;


### PR DESCRIPTION
### **User description**
Integrates a new `MiniCalendar.vue` component into the existing `MyCalendar.vue` sidebar.

The mini calendar provides a month-at-a-glance view, allowing you to:
- See the current month and year.
- Navigate to previous/next months, syncing with the main calendar.
- Click on a day to navigate the main calendar to that date.
- See the currently active day (from main calendar) highlighted.
- See the actual current day (today) highlighted.

The `MiniCalendar.vue` component is self-contained with its own logic for generating the month grid, handling navigation, and emitting events. It is integrated by replacing a placeholder in `MyCalendar.vue`, passing down the main calendar's current date and selected date as props, and handling selection/navigation events emitted by the mini calendar to update the main calendar's state.


___

### **PR Type**
Enhancement


___

### **Description**
- Introduced a new `MiniCalendar.vue` component for sidebar navigation.
  - Displays month grid, highlights today and selected day.
  - Allows month navigation and date selection, syncing with main calendar.

- Integrated `MiniCalendar` into `MyCalendar.vue` sidebar.
  - Replaced placeholder with interactive mini calendar.
  - Added event handlers to sync selected date and month.

- Removed obsolete mini calendar placeholder and related styles.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>MiniCalendar.vue</strong><dd><code>Add new MiniCalendar component with navigation and selection</code></dd></summary>
<hr>

src/components/MiniCalendar.vue

<li>Added new self-contained mini calendar Vue component.<br> <li> Implements month grid, navigation, and date selection logic.<br> <li> Emits events for date selection and month navigation.<br> <li> Includes scoped styles for calendar appearance.


</details>


  </td>
  <td><a href="https://github.com/ZainW/z-calendar/pull/26/files#diff-b054273d7069a2f1a923286a1acceff1cb93fdbbe5b7ffca77539a45aba3e4ae">+262/-0</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>MyCalendar.vue</strong><dd><code>Integrate MiniCalendar and remove placeholder from sidebar</code></dd></summary>
<hr>

src/components/MyCalendar.vue

<li>Integrated <code>MiniCalendar</code> component into sidebar.<br> <li> Connected mini calendar to main calendar state via props and events.<br> <li> Added handlers for date selection and month navigation.<br> <li> Removed placeholder markup and related CSS.


</details>


  </td>
  <td><a href="https://github.com/ZainW/z-calendar/pull/26/files#diff-3fedb4ce17255899585e120800d0980affa664fd0218b115e94070b711de65e5">+17/-33</a>&nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced an interactive mini calendar component with month navigation and date selection in the sidebar.
- **Improvements**
  - Enhanced sidebar calendar functionality, allowing users to select dates and switch months directly.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->