### PR TITLE
update rules

### DIFF
--- a/.cursor/rules/import-alias.mdc
+++ b/.cursor/rules/import-alias.mdc
@@ -1,0 +1,8 @@
+---
+description:
+globs:
+alwaysApply: false
+---
+- Use the `@/` alias for all imports from within the project.
+- Do not use relative paths like `../../` for internal imports.
+- Ensure your Vite and TypeScript config map `@` to the `src/` directory.

--- a/.cursor/rules/lint-on-save.mdc
+++ b/.cursor/rules/lint-on-save.mdc
@@ -1,0 +1,20 @@
+---
+description:
+globs:
+alwaysApply: false
+---
+- Linting is not enforced on commit, but should be run automatically on file save.
+- Instruct all contributors to enable the following in their `.vscode/settings.json`:
+
+```json
+{
+  "editor.codeActionsOnSave": {
+    "source.fixAll.eslint": true
+  },
+  "eslint.validate": [
+    "javascript",
+    "typescript",
+    "vue"
+  ]
+}
+```

--- a/.cursor/rules/linting.mdc
+++ b/.cursor/rules/linting.mdc
@@ -1,0 +1,9 @@
+---
+description:
+globs:
+alwaysApply: false
+---
+- Use `@antfu/eslint-config` as the primary ESLint config.
+- Enforce all Vue 3 "strongly recommended" style guide rules.
+- Let ESLint handle component naming and conventions.
+- Linting should be performed on save (recommend enabling `editor.codeActionsOnSave.source.fixAll.eslint` in VSCode).

--- a/.cursor/rules/test-location.mdc
+++ b/.cursor/rules/test-location.mdc
@@ -1,0 +1,8 @@
+---
+description:
+globs:
+alwaysApply: false
+---
+- All test files must be placed in the `__tests__` directory at the appropriate level.
+- Do not place test files outside of `__tests__`.
+- Use Vitest as the test runner.


### PR DESCRIPTION
### **PR Type**
documentation


___

### **Description**
- Add project-specific coding standards documentation.
  - Import alias usage guidelines.
  - Linting configuration and enforcement rules.
  - Test file location and runner requirements.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>import-alias.mdc</strong><dd><code>Add import alias usage rules and configuration requirements</code></dd></summary>
<hr>

.cursor/rules/import-alias.mdc

<li>Introduce rules for using the <code>@/</code> import alias.<br> <li> Prohibit relative paths for internal imports.<br> <li> Require Vite/TypeScript config to map <code>@</code> to <code>src/</code>.


</details>


  </td>
  <td><a href="https://github.com/ZainW/z-calendar/pull/27/files#diff-2f1929df65a4feb2e9a4ff87667233b5d70fc5360acef9e721bf51dc46a4d138">+8/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>lint-on-save.mdc</strong><dd><code>Document lint-on-save policy and VSCode setup</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.cursor/rules/lint-on-save.mdc

<li>Specify that linting should run on file save, not commit.<br> <li> Provide VSCode settings for auto-linting on save.<br> <li> List languages to validate with ESLint.


</details>


  </td>
  <td><a href="https://github.com/ZainW/z-calendar/pull/27/files#diff-4cfb196af4b91eaf123fcc079f971729009216a8707ed58747cebfb1a290d6cb">+20/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>linting.mdc</strong><dd><code>Add ESLint configuration and linting standards</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.cursor/rules/linting.mdc

<li>Mandate use of <code>@antfu/eslint-config</code>.<br> <li> Enforce Vue 3 style guide rules.<br> <li> Delegate component naming to ESLint.<br> <li> Recommend enabling auto-fix on save.


</details>


  </td>
  <td><a href="https://github.com/ZainW/z-calendar/pull/27/files#diff-110b5acef7b5469ca99cb36688b67d514416af7ccb16ccb579b20129a25822ec">+9/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>test-location.mdc</strong><dd><code>Define test file placement and runner requirements</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.cursor/rules/test-location.mdc

<li>Require all tests in <code>__tests__</code> directories.<br> <li> Forbid tests outside <code>__tests__</code>.<br> <li> Specify Vitest as the test runner.


</details>


  </td>
  <td><a href="https://github.com/ZainW/z-calendar/pull/27/files#diff-a23047a38fa71d648c5072347a4f549df3e68882dfd39abff0a687de025bb51a">+8/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Added guidelines for using import aliases, enforcing internal imports to use the `@/` alias.
  - Introduced rules for linting, including recommended ESLint configurations and enabling lint fixes on file save.
  - Provided instructions for organizing test files within `__tests__` directories and using Vitest as the test runner.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->